### PR TITLE
fix dependency versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app/
 RUN npm install .
 RUN npx webpack
 
-FROM acait/django-container:python3
+FROM acait/django-container:develop
 RUN mkdir /app/logs
 ADD setup.py /app/
 ADD requirements.txt /app/

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         'django==2.1',
         'django-webpack-loader',
         'django-compressor==2.2',
-        'UW-Django-SAML2',
+        'UW-Django-SAML2<1.3.4',
         'psycopg2',
         'djangorestframework',
         'phonenumbers',


### PR DESCRIPTION
tag base image with develop for faster dev cycles, and pin django saml version before it stopped supporting django 2.1