### PR TITLE
format preview box when no info entered

### DIFF
--- a/foodalert/sender.py
+++ b/foodalert/sender.py
@@ -66,7 +66,8 @@ class Sender:
             for allergen in message['food']['allergens']:
                 text += "{}, ".format(allergen)
             text = text[:-2]
-            text += '\n\n'
+            text += '\n'
+        text += '\n'
         if message['bring_container']:
             text += 'You must bring a container.\n\n'
 

--- a/foodalert/static/foodalert/js/pages/host/form-page.vue
+++ b/foodalert/static/foodalert/js/pages/host/form-page.vue
@@ -13,7 +13,7 @@
           We will send your notification to UW Food Alert Subscribers.
         </p>
         <preview-box>
-          <span>{{concatinateMessage()}}</span>
+          <span class="pre-formatted">{{concatinateMessage()}}</span>
           <br />
 
           <br />
@@ -181,28 +181,34 @@
 
         <h2 class="h2">Preview</h2>
         <preview-box>
-          <span class='pre-formatted'>{{concatinateMessage()}}</span>
-          <br />
-          <br />
-          End time:
-          <span v-if="form.end_time">{{formatedTimeToStr()}}</span>
-          <span v-else>--:-- --</span>
-          <br />
-          Location: <span v-if="form.location">{{form.location}}</span>
-          <span v-else>{{placeholderForm.location}}</span>
-          <span v-if="form.allergens.length != 0">
-            <br />
-            May contain:
-            <span v-for="(list, index) in form.allergens" :key="list">
-              <span>{{list}}</span><span
-              v-if="index+1<form.allergens.length">, </span>
-            </span>
-          </span>
-          <br />
-          <p v-if="form.bring_container" class="mb-0">
-            <br />
-            You must bring a food storage container.
+          <p v-if="!form.event || !form.food_served || !form.location"
+              class="preview-pretext">
+            Describe your event above to see a preview of the notification.
           </p>
+          <div v-else>
+            <span class='pre-formatted'>{{concatinateMessage()}}</span>
+            <br />
+            <br />
+            End time:
+            <span v-if="form.end_time">{{formatedTimeToStr()}}</span>
+            <span v-else>--:-- --</span>
+            <br />
+            Location: <span v-if="form.location">{{form.location}}</span>
+            <span v-else>{{placeholderForm.location}}</span>
+            <span v-if="form.allergens.length != 0">
+              <br />
+              May contain:
+              <span v-for="(list, index) in form.allergens" :key="list">
+                <span>{{list}}</span><span
+                v-if="index+1<form.allergens.length">, </span>
+              </span>
+            </span>
+            <br />
+            <p v-if="form.bring_container" class="mb-0">
+              <br />
+              You must bring a food storage container.
+            </p>
+          </div>
         </preview-box>
         <!--b-card class="mt-3" header="Form Data Result">
                     <pre class="m-0">{{ form }}</pre>
@@ -470,6 +476,12 @@ export default {
 <style>
 
 .pre-formatted {
-  white-space: pre;
+  white-space: pre-line;
+}
+
+.preview-pretext {
+  text-align: center;
+  font-style: italic;
+  margin: auto;
 }
 </style>


### PR DESCRIPTION
![foodalertPreview](https://user-images.githubusercontent.com/37788907/74281626-a64b8900-4cd3-11ea-93a6-513b41bcfc48.png)

Preview Box shows the above message when any of "event", "food description", or "location" is left empty
