### PR TITLE
Main element now takes up 100% width of the parent

### DIFF
--- a/foodalert/static/foodalert/js/components/generic-page.vue
+++ b/foodalert/static/foodalert/js/components/generic-page.vue
@@ -38,7 +38,7 @@
         </div>
       </main>
       <main id="standard-body"
-        class="mt-md-5 mt-3"
+        class="mt-md-5 mt-3 w-100"
         v-bind:class="pageSizeClass"
         v-show="!showUpdateOverlay">
         <h1 id="standard-heading">


### PR DESCRIPTION
Fixes resizing and overflow issues on mobile. Also makes the width of main element constant across /h and /s pages